### PR TITLE
Add missing reward message for crate rewards

### DIFF
--- a/LootCrates_v1.2/src/main/resources/messages.yml
+++ b/LootCrates_v1.2/src/main/resources/messages.yml
@@ -46,6 +46,7 @@ keys:
 
 # Reward messages
 rewards:
+  reward_received: "&aYou received: &f{reward}"
   received: "&aYou received: &f{reward_display}"
   broadcast_common: "&e{player} &areceived &f{reward_display} &afrom {crate_display}!"
   broadcast_rare: "&6✦ &e{player} &6received the rare reward &f{reward_display} &6from {crate_display}! &6✦"


### PR DESCRIPTION
## Summary
- add the missing `rewards.reward_received` translation string used when opening crates
- ensure the message uses the reward placeholder expected by the code so crate openings no longer warn about a missing message

## Testing
- `./gradlew build` *(fails: script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e36db6d88325b514955211c75041